### PR TITLE
Url fixes

### DIFF
--- a/_coverpage.md
+++ b/_coverpage.md
@@ -1,4 +1,4 @@
-![Suggester Logo](https://suggester.js.org/images/logo.png)
+![Suggester Logo](/images/logo.png)
 
 - A Discord bot that helps you manage your server suggestions
 

--- a/admin/autosetup.md
+++ b/admin/autosetup.md
@@ -3,7 +3,7 @@
 ### Description
 This command is used to automatically set up server channels/roles to work with Suggester.
 
-!>Initiating automatic setup will change some of the settings currently set on your server. It will also create several new channels on your server. If you are looking for other configuration options, take a look at the [setup](https://suggester.js.org/#/admin/setup) or [config](https://suggester.js.org/#/admin/config) commands.
+!>Initiating automatic setup will change some of the settings currently set on your server. It will also create several new channels on your server. If you are looking for other configuration options, take a look at the [setup](/admin/setup.md) or [config](/admin/config.md) commands.
 
 ### Usage
 ```

--- a/admin/autosetup.md
+++ b/admin/autosetup.md
@@ -3,7 +3,7 @@
 ### Description
 This command is used to automatically set up server channels/roles to work with Suggester.
 
-!>Initiating automatic setup will change some of the settings currently set on your server. It will also create several new channels on your server. If you are looking for other configuration options, take a look at the [setup](https://suggester.js.org/#/admin/config) or [config](https://suggester.js.org/#/admin/config) commands.
+!>Initiating automatic setup will change some of the settings currently set on your server. It will also create several new channels on your server. If you are looking for other configuration options, take a look at the [setup](https://suggester.js.org/#/admin/setup) or [config](https://suggester.js.org/#/admin/config) commands.
 
 ### Usage
 ```

--- a/admin/config.md
+++ b/admin/config.md
@@ -161,7 +161,7 @@ This command is used to set various settings without needing to go through the f
 ### `implemented`
 ## Function
 
-**The channel where all suggestions that have been marked as __implemented__ using the [mark](https://suggester.js.org/#/staff/mark) command are sent.**
+**The channel where all suggestions that have been marked as __implemented__ using the [mark](/staff/mark.md) command are sent.**
 
 **Using** `none` **as the channel will remove the implemented archive channel if there is one set.**
 

--- a/admin/config.md
+++ b/admin/config.md
@@ -1,5 +1,5 @@
 # Config
- 
+
 ### Description
 This command is used to set various settings without needing to go through the full setup.
 ### Optional Arguments
@@ -16,170 +16,170 @@ This command is used to set various settings without needing to go through the f
 
 ### `admin`
 ## Function
- 
+
 **Anyone with any of these roles inherits staff permissions, but also has permission to configure server settings.**
 
 ## Valid Inputs
- 
+
 **Role name, ID, or @mention**
 
 ## Usage
- 
+
 `config admin [add/remove/list] [role]`
 
 #### **Staff Roles**
 
 ## Config Element
- 
+
 ### `staff`
 ## Function
- 
+
 **Anyone with any of these roles has permission to accept and deny suggestions, as well as interact with them in other ways.**
 
 ## Valid Inputs
- 
+
 **Role name, ID, or @mention**
 
 ## Usage
- 
+
 `config staff [add/remove/list] [role]`
 
 #### **Allowed Suggestion Roles**
 
 ## Config Element
- 
+
 ### `allowed`
 ## Function
- 
+
 **Anyone with any of these roles (or a staff/admin role) can submit suggestions. If no allowed roles are set, all members can submit suggestions.**
 
 ?> This is useful for locking suggesting to only some members of your server!
 
 ## Valid Inputs
- 
+
 **Role name, ID, or @mention**
 
 ## Usage
- 
+
 `config allowed [add/remove/list] [role]`
 
 #### **Approved Suggestion Role**
 
 ## Config Element
- 
+
 ### `approvedrole`
 ## Function
- 
+
 **When a member's suggestion is approved they will automatically receive this role.**
 
 **Using** `none` **as the value will remove the approved suggestion role if there is one set.**
 
 ## Valid Inputs
- 
+
 **Role name, ID, or @mention**
 
 ## Usage
- 
+
 `config allowed [role]`
 
 #### **Review Channel**
 
 ## Config Element
- 
+
 ### `review`
 ## Function
- 
+
 **The channel where suggestions are sent immediately after submission to be reviewed by staff. (Only if the mode is set to *review*)**
 
 ## Valid Inputs
- 
+
 **Channel ID, name or #mention**
 
 ## Usage
- 
+
 `config review [channel]`
 
 #### **Approved Suggestions Channel**
 
 ## Config Element
- 
+
 ### `suggestions`
 ## Function
- 
+
 **The channel where approved suggestions are posted. (If the mode is set to *autoapprove* then suggestions are automatically posted here)**
 
 ## Valid Inputs
- 
+
 **Channel ID, name or #mention**
 
 ## Usage
- 
+
 `config suggestions [channel]`
 
 #### **Denied Suggestions Channel**
 
 ## Config Element
- 
+
 ### `denied`
 ## Function"
- 
+
 **The channel where suggestions that are denied/deleted are posted.**
 
 **Using** `none` **as the channel will remove the denied suggestions channel if there is one set.**
 
 ## Valid Inputs
- 
+
 **Channel ID, name or #mention or** `none`
 
 ## Usage
- 
+
 `config denied [channel]`
 
 #### **Log Channel**
 
 ## Config Element
- 
+
 ### `logs`
 ## Function
- 
+
 **The channel where all actions taken on suggestions are logged.**
 
 **Using** `none` **as the channel will remove the log channel if there is one set.**
 
 ## Valid Inputs
- 
+
 **Channel ID, name or #mention or** `none`
 
 ## Usage
- 
+
 `config logs [channel]`
 
 #### **Implemented Archive Channel**
 
 ## Config Element
- 
+
 ### `implemented`
 ## Function
- 
+
 **The channel where all suggestions that have been marked as __implemented__ using the [mark](https://suggester.js.org/#/staff/mark) command are sent.**
 
 **Using** `none` **as the channel will remove the implemented archive channel if there is one set.**
 
 ## Valid Inputs
- 
+
 **Channel ID, name or #mention or** `none`
 
 ## Usage
- 
+
 `config implemented [channel]`
 
 #### **Suggestion Command Channel**
 
 ## Config Element
- 
+
 ### `commands`
 ## Function
- 
+
 **The channel where the** `suggest` **command can be used. (If this is not set the suggest command can be used in any channel)**
 
 ?> This is useful for keeping suggest commands out of chat channels!
@@ -187,20 +187,20 @@ This command is used to set various settings without needing to go through the f
 **Using** `none` **as the channel will remove the implemented archive channel if there is one set.**
 
 ## Valid Inputs
- 
+
 **Channel ID, name or #mention or** `none`
 
 ## Usage
- 
+
 `config commands [channel]`
 
 #### **Reaction Emojis**
 
 ## Config Element
- 
+
 ### `emojis`
 ## Function
- 
+
 **The emojis that should be reacted on approved suggestions. The defaults are 👍, 🤷, and 👎 for upvote, shrug, and downvote respectively.**
 
 **Selecting** `disable` **for an emote disables it - meaning it won't be added to future approved suggestions.**
@@ -208,39 +208,39 @@ This command is used to set various settings without needing to go through the f
 **The** `toggle`/`enable`/`disable` **parameters will edit the setting controlling reactions to suggestion feed posts - this is *enabled* by default.**
 
 ## Valid Inputs
- 
+
 **Unicode or custom emoji from the server.**
 
 ## Usage
- 
+
 `config emojis [upvote/shrug/downvote/toggle/enable/disable] [emoji/disable]`
 
 #### **Notify Settings**
 
 ## Config Element
- 
+
 ### `notify`
 ## Function
- 
+
 **The** `notify` **element specifies whether server members should be notified through DM when actions are taken on their suggestions.**
 
 **This is *enabled* by default.**
 
 ## Valid Inputs
- 
+
 `enable`, `disable`, **or** `toggle`
 
 ## Usage
- 
+
 `config notify [enable/disable/toggle]`
 
 #### **Suggestions Mode**
 
 ## Config Element
- 
+
 ### `mode`
 ## Function
- 
+
 **The** `mode` **element configures the mode of suggestion handling.**
 
 **Setting this to** `review` **will put all suggestions through the review process before sending them to the suggestions channel.**
@@ -248,20 +248,20 @@ This command is used to set various settings without needing to go through the f
 **Setting this to** `autoapprove` **will automatically send all submitted suggestions to the suggestions feed.**
 
 ## Valid Inputs
- 
+
 `review` **or** `autoapprove`
 
 ## Usage
- 
+
 `config mode [review/autoapprove]`
 
 #### **Auto-Clean Suggestion Channel**
 
 ## Config Element
- 
+
 ### `cleancommands`
 ## Function
- 
+
 **This element specifies whether or not suggestion commands and responses are deleted after a few seconds.**
 
 **This is *disabled* by default.**
@@ -269,11 +269,11 @@ This command is used to set various settings without needing to go through the f
 ?> This is useful for keeping your suggestion channel clean!
 
 ## Valid Inputs
- 
+
 **Channel ID, name or #mention**
 
 ## Usage
- 
+
 `config suggestions [channel]`
 
 #### **Prefix**
@@ -293,10 +293,7 @@ This command is used to set various settings without needing to go through the f
 
 `config prefix [prefix]`
 
-#### ****
 <!-- tabs:end -->
-
-
 
 
 ### Usage

--- a/admin/setup.md
+++ b/admin/setup.md
@@ -3,7 +3,7 @@
 ### Description
 This command is used to set up the server through interactive guide.
 
-!>Initiating setup will wipe all the settings currently set on your server. If you already have configuration elements set, the bot will warn you and give you a chance to abort the command. Once you have confirmed you would like to initiate setup, there is no going back. If you want to configure the bot without clearing all your settings, take a look at the [config](https://suggester.js.org/#/admin/config) command.
+!>Initiating setup will wipe all the settings currently set on your server. If you already have configuration elements set, the bot will warn you and give you a chance to abort the command. Once you have confirmed you would like to initiate setup, there is no going back. If you want to configure the bot without clearing all your settings, take a look at the [config](/admin/config.md) command.
 
 ### Usage
 ```

--- a/index.html
+++ b/index.html
@@ -6,7 +6,7 @@
     <meta http-equiv="X-UA-Compatible" content="IE=edge">
     <meta name="viewport" content="width=device-width, initial-scale=1, minimum-scale=1.0, shrink-to-fit=no, viewport-fit=cover">
     <title>Suggester Docs</title>
-    <link rel="icon" type="image/ico" href="https://suggester.js.org/images/favicon.ico">
+    <link rel="icon" type="image/ico" href="/images/favicon.ico">
     <meta property="og:site_name" content="Suggester Docs">
     <meta property="twitter:card" content="summary_large_image">
     <meta name="description" content="The official documentation for the Suggester Discord bot">
@@ -53,7 +53,7 @@
             // -----------------------------------------------------------------
             name: 'Suggester Docs',
             homepage: 'home.md',
-            logo: 'https://suggester.js.org/images/logo.png',
+            logo: '/images/logo.png',
             loadSidebar: true,
             coverpage: true,
             loadNavbar: true,


### PR DESCRIPTION
- All the links to docs were changed to relative-to-root URLs (if they weren't already).
- Fixed [a spot](https://github.com/Suggester-Bot/Documentation/pull/5/commits/bf06eb6eb6fc3b957dc85bd77247f1a0db4d2565#diff-f92bd7a772337e1f73d43d8383dbecc4L6) in `autosetup.md` that said it linked to both `setup.md`, but pointed to `config.md`.
- Removed [a random `#### ****`](https://github.com/Suggester-Bot/Documentation/pull/5/commits/333e3c353471d59586bc68ff676ad034e5168204#diff-9fd5574e1319a6be887f7069d8d3e910L296) in `config.md`.
- Trimmed trailing single spaces in `config.md`.