### PR TITLE
Changed some stuff

### DIFF
--- a/admin/autosetup.md
+++ b/admin/autosetup.md
@@ -3,7 +3,7 @@
 ### Description
 Automatically setup the bot.
 
-!>Using `autosetup` will automaticall create four channels, one for suggestions, one for denied suggestions, one for pending suggestions and one one for logs. If you are looking for more granular options, take a look at the [setup](/admin/setup.md) and [config](/admin/config.md) commands.
+!>Using `autosetup` will automatically create four channels, one for suggestions, one for denied suggestions, one for pending suggestions and one one for logs. If you are looking for more granular options, take a look at the [setup](/admin/setup.md) and [config](/admin/config.md) commands.
 
 ### Usage
 ```

--- a/admin/autosetup.md
+++ b/admin/autosetup.md
@@ -1,13 +1,13 @@
 # Autosetup
 ---
 ### Description
-This command is used to automatically set up server channels/roles to work with Suggester.
+Automatically setup the bot.
 
-!>Initiating automatic setup will change some of the settings currently set on your server. It will also create several new channels on your server. If you are looking for other configuration options, take a look at the [setup](/admin/setup.md) or [config](/admin/config.md) commands.
+!>Using `autosetup` will automaticall create four channels, one for suggestions, one for denied suggestions, one for pending suggestions and one one for logs. If you are looking for more granular options, take a look at the [setup](/admin/setup.md) and [config](/admin/config.md) commands.
 
 ### Usage
 ```
 .autosetup
 ```
 ### Permission Required
-People with **Manage Server** permission or configured admin role.
+The user must have **Manage Server** or the configured admin role.

--- a/admin/autosetup.md
+++ b/admin/autosetup.md
@@ -3,7 +3,7 @@
 ### Description
 Automatically setup the bot.
 
-!>Using `autosetup` will automatically create four channels, one for suggestions, one for denied suggestions, one for pending suggestions and one one for logs. If you are looking for more granular options, take a look at the [setup](/admin/setup.md) and [config](/admin/config.md) commands.
+!>Using `autosetup` will automatically create four channels, one for suggestions, one for denied suggestions, one for pending suggestions and one for logs. If you are looking for more granular options, take a look at the [setup](/admin/setup.md) and [config](/admin/config.md) commands.
 
 ### Usage
 ```

--- a/admin/config.md
+++ b/admin/config.md
@@ -1,11 +1,13 @@
 # Config
 
 ### Description
-This command is used to set various settings without needing to go through the full setup.
+Configure individual options for the bot.
 ### Optional Arguments
-`list` - This argument is used to show current server settings.
+`list` - Show the server's current configuration.
 
-`element` - If this is used without any other argument, it will show current settings for that element.
+`element` - The setting to change.
+
+`...input` - The value of the setting you would like to change. Leaving this blank will show the current value.
 
 
 *For configuration*
@@ -17,7 +19,7 @@ This command is used to set various settings without needing to go through the f
 ### `admin`
 ## Function
 
-**Anyone with any of these roles inherits staff permissions, but also has permission to configure server settings.**
+**The admin role automatically inherits all staff permissions and the ability to configure server settings.**
 
 ## Valid Inputs
 
@@ -25,7 +27,7 @@ This command is used to set various settings without needing to go through the f
 
 ## Usage
 
-`config admin [add/remove/list] [role]`
+`config admin [<add|remove|list> <role>]`
 
 #### **Staff Roles**
 
@@ -34,7 +36,7 @@ This command is used to set various settings without needing to go through the f
 ### `staff`
 ## Function
 
-**Anyone with any of these roles has permission to accept and deny suggestions, as well as interact with them in other ways.**
+**The staff roles grant permission to interact with suggestions (approve, deny, etc.).**
 
 ## Valid Inputs
 
@@ -42,7 +44,7 @@ This command is used to set various settings without needing to go through the f
 
 ## Usage
 
-`config staff [add/remove/list] [role]`
+`config staff [<add|remove|list> <role>]`
 
 #### **Allowed Suggestion Roles**
 
@@ -51,9 +53,9 @@ This command is used to set various settings without needing to go through the f
 ### `allowed`
 ## Function
 
-**Anyone with any of these roles (or a staff/admin role) can submit suggestions. If no allowed roles are set, all members can submit suggestions.**
+**Annyone with these roles can sumbit suggestions. If this is left blank, all members may submit suggestions.**
 
-?> This is useful for locking suggesting to only some members of your server!
+?> This is useful for locking the ability to make suggestions to specific server members.
 
 ## Valid Inputs
 
@@ -61,7 +63,7 @@ This command is used to set various settings without needing to go through the f
 
 ## Usage
 
-`config allowed [add/remove/list] [role]`
+`config allowed [<add|remove|list> <role>]`
 
 #### **Approved Suggestion Role**
 
@@ -70,9 +72,9 @@ This command is used to set various settings without needing to go through the f
 ### `approvedrole`
 ## Function
 
-**When a member's suggestion is approved they will automatically receive this role.**
+**When a member's suggestion is approved, they will automatically receive this role.**
 
-**Using** `none` **as the value will remove the approved suggestion role if there is one set.**
+**Using** `none` **as the value will remove the approved suggestion role if one is set.**
 
 ## Valid Inputs
 
@@ -89,11 +91,11 @@ This command is used to set various settings without needing to go through the f
 ### `review`
 ## Function
 
-**The channel where suggestions are sent immediately after submission to be reviewed by staff. (Only if the mode is set to *review*)**
+**The channel where suggestions are sent to be reviewed by server staff. (This channel will only be used if the mode is set to *review*)**
 
 ## Valid Inputs
 
-**Channel ID, name or #mention**
+**Channel name, ID or #mention**
 
 ## Usage
 
@@ -106,11 +108,11 @@ This command is used to set various settings without needing to go through the f
 ### `suggestions`
 ## Function
 
-**The channel where approved suggestions are posted. (If the mode is set to *autoapprove* then suggestions are automatically posted here)**
+**The channel is where approved suggestions will be sent. (If the mode is set to *autoapprove*, suggestions will automatically be posted here)**
 
 ## Valid Inputs
 
-**Channel ID, name or #mention**
+**Channel name, ID or #mention**
 
 ## Usage
 
@@ -123,13 +125,13 @@ This command is used to set various settings without needing to go through the f
 ### `denied`
 ## Function"
 
-**The channel where suggestions that are denied/deleted are posted.**
+**The channel where suggestions that are denied or deleted are posted.**
 
-**Using** `none` **as the channel will remove the denied suggestions channel if there is one set.**
+**Using** `none` **will remove the denied suggestions channel if one is set.**
 
 ## Valid Inputs
 
-**Channel ID, name or #mention or** `none`
+**Channel name, ID, #mention or** `none`
 
 ## Usage
 
@@ -144,11 +146,11 @@ This command is used to set various settings without needing to go through the f
 
 **The channel where all actions taken on suggestions are logged.**
 
-**Using** `none` **as the channel will remove the log channel if there is one set.**
+**Using** `none` **will remove the log channel if one is set.**
 
 ## Valid Inputs
 
-**Channel ID, name or #mention or** `none`
+**Channel name, ID, #mention or** `none`
 
 ## Usage
 
@@ -161,13 +163,13 @@ This command is used to set various settings without needing to go through the f
 ### `implemented`
 ## Function
 
-**The channel where all suggestions that have been marked as __implemented__ using the [mark](/staff/mark.md) command are sent.**
+**The channel where all suggestions that have been marked as __implemented__ are sent.**
 
-**Using** `none` **as the channel will remove the implemented archive channel if there is one set.**
+**Using** `none` **will remove the implemented suggestions channel if one is set.**
 
 ## Valid Inputs
 
-**Channel ID, name or #mention or** `none`
+**Channel name, ID, #mention or** `none`
 
 ## Usage
 
@@ -180,15 +182,15 @@ This command is used to set various settings without needing to go through the f
 ### `commands`
 ## Function
 
-**The channel where the** `suggest` **command can be used. (If this is not set the suggest command can be used in any channel)**
+**The channel where the** `suggest` **command can be used. (If this is not set, the** `suggest` **command can be used in any channel)**
 
 ?> This is useful for keeping suggest commands out of chat channels!
 
-**Using** `none` **as the channel will remove the implemented archive channel if there is one set.**
+**Using** `none` **will remove the suggestion channel if one is set.**
 
 ## Valid Inputs
 
-**Channel ID, name or #mention or** `none`
+**Channel name, ID, #mention or** `none`
 
 ## Usage
 
@@ -201,11 +203,9 @@ This command is used to set various settings without needing to go through the f
 ### `emojis`
 ## Function
 
-**The emojis that should be reacted on approved suggestions. The defaults are 👍, 🤷, and 👎 for upvote, shrug, and downvote respectively.**
+**The reactions that will be added to approved suggestions. By default, 👍, 🤷 and 👎 will be used.**
 
-**Selecting** `disable` **for an emote disables it - meaning it won't be added to future approved suggestions.**
-
-**The** `toggle`/`enable`/`disable` **parameters will edit the setting controlling reactions to suggestion feed posts - this is *enabled* by default.**
+**Selecting** `disable` **will disable it, meaning it will not be added to approved suggestions in the future.**
 
 ## Valid Inputs
 
@@ -213,7 +213,7 @@ This command is used to set various settings without needing to go through the f
 
 ## Usage
 
-`config emojis [upvote/shrug/downvote/toggle/enable/disable] [emoji/disable]`
+`config emojis [<upvote|shrug|downvote|toggle|enable|disable>] [emoji|disable]`
 
 #### **Notify Settings**
 
@@ -222,17 +222,17 @@ This command is used to set various settings without needing to go through the f
 ### `notify`
 ## Function
 
-**The** `notify` **element specifies whether server members should be notified through DM when actions are taken on their suggestions.**
+**The** `notify` **element specifies whether server members will be notified when actions are taken on suggestions they have submitted.**
 
 **This is *enabled* by default.**
 
 ## Valid Inputs
 
-`enable`, `disable`, **or** `toggle`
+`enable`, `disable` **or** `toggle`
 
 ## Usage
 
-`config notify [enable/disable/toggle]`
+`config notify [enable|disable|toggle]`
 
 #### **Suggestions Mode**
 
@@ -243,9 +243,9 @@ This command is used to set various settings without needing to go through the f
 
 **The** `mode` **element configures the mode of suggestion handling.**
 
-**Setting this to** `review` **will put all suggestions through the review process before sending them to the suggestions channel.**
+**Setting the mode to** `review` **will send all suggestions to the review channel before sending them to the suggestions channel.**
 
-**Setting this to** `autoapprove` **will automatically send all submitted suggestions to the suggestions feed.**
+**Setting the mode to** `autoapprove` **will automatically send all submitted suggestions directly to the suggestions feed.**
 
 ## Valid Inputs
 
@@ -253,7 +253,7 @@ This command is used to set various settings without needing to go through the f
 
 ## Usage
 
-`config mode [review/autoapprove]`
+`config mode [review|autoapprove]`
 
 #### **Auto-Clean Suggestion Channel**
 
@@ -262,7 +262,7 @@ This command is used to set various settings without needing to go through the f
 ### `cleancommands`
 ## Function
 
-**This element specifies whether or not suggestion commands and responses are deleted after a few seconds.**
+**This will automatically deletes suggestion commands and the bot's response shortly after running the command.**
 
 **This is *disabled* by default.**
 
@@ -274,7 +274,7 @@ This command is used to set various settings without needing to go through the f
 
 ## Usage
 
-`config cleancommands [enable/disable/toggle]`
+`config cleancommands [enable|disable|toggle]`
 
 #### **Prefix**
 
@@ -283,7 +283,9 @@ This command is used to set various settings without needing to go through the f
 ### `prefix`
 ## Function
 
-**The prefix that all commands start with Example: in** `.command` **the prefix is** `.`
+**The prefix that will be used for all of Suggester's commands**
+
+**The default prefix is** `.`
 
 ## Valid Inputs
 
@@ -298,9 +300,9 @@ This command is used to set various settings without needing to go through the f
 
 ### Usage
 ```
-.config (element) (additional parameters)
+.config <element> [additional parameters]
 ```
 ### Aliases
 `serverconfig`, `cfg`, `configure`
 ### Required Permissions
-People with **Manage Server** permission or configured admin role.
+The user must have **Manage Server** or the configured admin role.

--- a/admin/setup.md
+++ b/admin/setup.md
@@ -1,13 +1,13 @@
 # Setup
 ---
 ### Description
-This command is used to set up the server through interactive guide.
+Setup Suggester using an interactive wizard-like setup process.
 
-!>Initiating setup will wipe all the settings currently set on your server. If you already have configuration elements set, the bot will warn you and give you a chance to abort the command. Once you have confirmed you would like to initiate setup, there is no going back. If you want to configure the bot without clearing all your settings, take a look at the [config](/admin/config.md) command.
+!>Using `setup` will erase any settings currently set on your server. If you want to configure specific settings, use the [config](/admin/config.md) command.
 
 ### Usage
 ```
 .setup
 ```
 ### Permission Required
-People with **Manage Server** permission or configured admin role.
+The user must have **Manage Server** or the configured admin role.

--- a/all/changelog.md
+++ b/all/changelog.md
@@ -1,7 +1,7 @@
 # Changelog
 ---
 ### Description
-This command shows the latest release changelog from the [Suggester GitHub Repo](https://github.com/Suggester-Bot/Suggester).
+Show the [latest release](https://github.com/Suggester-Bot/Suggester/releases/latest) changelog.
 ### Usage
 ```
 .changelog
@@ -9,4 +9,4 @@ This command shows the latest release changelog from the [Suggester GitHub Repo]
 ### Aliases
 `changes`
 ### Permission Required
-Anyone can use this command, unless they are blacklisted in the server or globally.
+Anyone can use this command

--- a/all/help.md
+++ b/all/help.md
@@ -1,14 +1,14 @@
 # Help
 ---
 ### Description
-This command shows help about either a single command or provides the link to the documentation.
+Get help with a command.
 ### Optional Arguments
-`command` - A command name to get detailed help about
+`command` - The name of a command
 ### Usage
 ```
-.help (command)
+.help [command]
 ```
 ### Aliases
 `command`, `howto`
 ### Permission Required
-Anyone can use this command, unless they are blacklisted in the server or globally.
+Anyone can use this command

--- a/all/invite.md
+++ b/all/invite.md
@@ -1,10 +1,10 @@
 # Invite
 ---
 ### Description
-This command is used to show the link to [invite the bot to your server](https://discord.com/oauth2/authorize?client_id=564426594144354315&scope=bot&permissions=805694544).
+Get the bot's [invitation link](https://discord.com/oauth2/authorize?client_id=564426594144354315&scope=bot&permissions=805694544).
 ### Usage
 ```
 .invite
 ```
 ### Permission Required
-Anyone can use this command, unless they are blacklisted in the server or globally.
+Anyone can use this command

--- a/all/notify.md
+++ b/all/notify.md
@@ -1,18 +1,18 @@
 # Notify
 ---
 ### Description
-This command is used to manage your notifications from the bot.
+Enable or disable notifications from the bot.
 ### Required Arguments
-`on` - Turns your notification on.
-`off` - Turns your notification off.
-`toggle` - Change your notification mode to the opposite of your current one.
+`on` - Enable notifications
+`off` - Disable notifications
+`toggle` - Toggle the current state
 ### Subcommand
-`self` - This subcommand is used to decide if you get notification when you take action on __your suggestions__.
+`self` - Change the notification settings for when __you__ perform an action on __your own suggestion__.
 ### Usage
 ```
-.notify (self) <on|off|toggle>
+.notify [self] [on|off|toggle]
 ```
 ### Aliases
 `notifications`
 ### Permission Required
-Anyone can use this command unless they are blacklisted in the server or globally.
+Anyone can use this command

--- a/all/ping.md
+++ b/all/ping.md
@@ -1,7 +1,7 @@
 # Ping
 ---
 ### Description
-This command is used to show the response time of the bot.
+Display the response time of the bot, as well as some other info about the bot.
 ### Usage
 ```
 .ping
@@ -9,4 +9,4 @@ This command is used to show the response time of the bot.
 ### Aliases
 `hi`, `bot`, `about`, `bot`
 ### Permission Required
-Anyone can use this command, unless they are blacklisted in the server or globally.
+Anyone can use this command

--- a/all/stats.md
+++ b/all/stats.md
@@ -1,7 +1,7 @@
 # Stats
 ---
 ### Description
-This command is used to check the stats of suggester, Globally and in the server.
+Show some statistics about the bot.
 ### Usage
 ```
 .stats
@@ -9,4 +9,4 @@ This command is used to check the stats of suggester, Globally and in the server
 ### Aliases
 `statistics`
 ### Permission Required
-Anyone can use this command, unless they are blacklisted in the server or globally.
+Anyone can use this command

--- a/all/suggest.md
+++ b/all/suggest.md
@@ -1,16 +1,16 @@
 # Suggest
 ---
 ### Description
-This command is used to suggest things to the staff team of a server.
+Submit a suggestion!
 ### Required Arguments
-`suggestion` - The suggestion you want to submit, it can include anything.
+`suggestion` - Your *amazing* suggestion
 
-?> You can include attachments with your suggestion, you can add it by attaching it as a file, the attachment can be `jpg`, `png`, `jpeg` or `gif`.
+?> You can even include an image with your suggestion, just upload it with your suggestion. Supported file types: `jpg`, `png`, `jpeg`, `gif`.
 ### Usage
 ```
-.suggest [suggestion]
+.suggest <suggestion>
 ```
 ### Aliases
 `submit`
 ### Permission Required
-Anyone can use this command, unless they are blacklisted in the server or globally or the server admins have set up an Allowed Suggestion Role.
+This command can be used by any user by default. This can be changed to require a specific role.

--- a/all/support.md
+++ b/all/support.md
@@ -1,10 +1,10 @@
 # Support
 ---
 ### Description
-This command is used to show the invite link to the support server.
+Show some info about how to get in touch with the support team.
 ### Usage
 ```
 .support
 ```
 ### Permission Required
-Anyone can use this command, unless they are blacklisted in the server or globally.
+Anyone can use this command

--- a/all/verify.md
+++ b/all/verify.md
@@ -1,12 +1,12 @@
 # Verify
 ---
 ### Description
-This command is used to show the acknowledgements of a user
+Show a user's permissions as they relate to the bot.
 ### Optional Arguments
-`user` - The user you want information about, it can be a user ID or a mention
+`user` - The user's ID or mention
 ### Usage
 ```
-.verify (user)
+.verify [user]
 ```
 ### Permission Required
-Anyone can use this command, unless they are blacklisted in the server or globally
+Anyone can use this command

--- a/all/vote.md
+++ b/all/vote.md
@@ -1,10 +1,10 @@
 # Vote
 ---
 ### Description
-This command is used to show information about voting for suggester on all the bot lists it is on. (You can also check out how to vote [here](supporting/info.md))
+Show information about voting for Suggester on several bot lists. (You can learn more about voting [here](supporting/info.md) as well.)
 ### Usage
 ```
 .vote
 ```
 ### Permission Required
-Anyone can use this command, unless they are blacklisted in the server or globally
+Anyone can use this command

--- a/getting-started.md
+++ b/getting-started.md
@@ -2,12 +2,12 @@
 ---
 
 ## **Step 1: Invite the Bot**
-You can invite the bot using [this link](https://discord.com/oauth2/authorize?client_id=564426594144354315&scope=bot&permissions=805694544). The bot needs all permissions shown in order to function correctly. If these permissions are not present some functions may not work. The bot can be invited to any server where you have the **Manage Server** permission.
+You can add the bot to your server by using [this link](https://discord.com/oauth2/authorize?client_id=564426594144354315&scope=bot&permissions=805694544). The bot needs all permissions shown to function correctly. If any of these permissions are missing, some functions may not work. The bot can be invited to any server where you have the **Manage Server** permission.
 
 ## **Step 2: Configure the Bot**
-In order for the bot to work, it must be configured. See the [setup](admin/setup.md) documentation page for more information about how to start configuring the bot!
+In order for the bot to work, it must be configured. There are three ways to setup the bot, [autosetup](admin/autosetup.md), a wizard-like [setup](admin/setup.md) and a fully manual [config](admin/config.md).
 
 ## **Step 3: Get suggesting!**
-You and your members can now use the [suggest](all/suggest.md) command to suggest stuff.
+You can now use the [suggest](all/suggest.md) command to submit suggestions!
 
 ?> If you have any issues configuring the bot, please join our [support server](https://discord.gg/G5pEdUp) to receive assistance!

--- a/home.md
+++ b/home.md
@@ -1,7 +1,7 @@
 # Suggester Docs {docsify-ignore-all}
 ---
-Suggester is an [open source](https://github.com/Suggester-Bot/Suggester) bot that manages server suggestions, allowing staff to review suggestions before they are posted and manage them in many ways. This site has the documentation of all commands, as well as some other helpful information.
+Suggester is an [open source](https://github.com/Suggester-Bot/Suggester) bot that manages server suggestions. On this site, we have documented what all of Suggester's commands and how to use them.
 
-?> All **Usage** sections on these docs will assume that the command prefix is the default `.` prefix that is set when the bot is added to a server. The `config` command gives the option of changing the prefix, and if your server's prefix has been changed you should replace `.` with that prefix.
+?> All **Usage** sections on these docs will assume that the prefix  is `.` You can change your server's prefix using the [config](admin/config.md) command.
 
-?> In this documentation, arguments in [brackets] are required, while arguments in (parenthesis) are optional. You also should not type out the brackets and parenthesis when using the commands.
+?> In this documentation, arguments in <angle brackets> are __required__ and [square brackets] are __optional__.

--- a/staff/acomment.md
+++ b/staff/acomment.md
@@ -1,18 +1,18 @@
 # Acomment
 ---
 ### Description
-This command allows staff members to anonymously comment on a suggestion. This comment will be displayed publicly in the suggestion embed.
+Add an anonymous comment to a suggestion.
 ### Required Arguments
-`suggestion ID` - The ID of the suggestion you want to comment on.
+`suggestionId` - The ID of the suggestion
 
-`comment` - The comment to add to the suggestion.
+`comment` - The comment to add
 
 !> A suggestion can have a maximum of 23 comments
 ### Usage
 ```
-.acomment [suggestion id] [comment]
+.acomment <suggestionId> <comment>
 ```
 ### Aliases
 `anonymouscomment`
 ### Permission Required
-Any user with the **Manage Server** permission, a configured admin role or a configured staff role can use this command.
+The user must have **Manage Server** or a configured staff role.

--- a/staff/approve.md
+++ b/staff/approve.md
@@ -1,14 +1,14 @@
 # Approve
 ---
 ### Description
-This command is used to approve suggestions in review mode.
+Approve a suggestion (while in `review` mode).
 ### Required Arguments
-`suggestion ID` - The ID of the suggestion you want to approve.
+`suggestionId` - The ID of the suggestion.
 ### Optional Arguments
-`comment` - Comment you want to include in the suggestion.
+`comment` - A comment to add to the approved suggestion.
 ### Usage
 ```
-.approve [suggestion ID] (comment)
+.approve <suggestionId> [comment]
 ```
 ### Permission Required
-Any user with the **Manage Server** permission, a configured admin role or a configured staff role can use this command.
+The user must have **Manage Server** or a configured staff role.

--- a/staff/attach.md
+++ b/staff/attach.md
@@ -1,14 +1,14 @@
 # Attach
 ---
 ### Description
-This command is used to attach images to approved suggestions.
+Attact an image to a suggestion in the suggestion feed.
 ### Required Arguments
-`suggestion ID` - The suggestion ID you want to attach a file to it.
+`suggestionId` - The suggestion ID
 
-`attachment` - It can `jpg` `png` `jpeg` and `gif` file.
+`attachment` - The image to attach. It must be a `png`, `jpg`, `jpeg` or `gif` file.
 ### Usage
 ```
-.attach [suggestion ID] [attachment]
+.attach <suggestionId> <attachment>
 ```
 ### Permission Required
-Any user with the **Manage Server** permission, a configured admin role or a configured staff role can use this command.
+The user must have **Manage Server** or a configured staff role.

--- a/staff/blacklist.md
+++ b/staff/blacklist.md
@@ -1,14 +1,14 @@
 # Blacklist
 ---
 ### Description
-This command is used prevent people from using the bot in the server.
+This command is used blacklist people from using the bot.
 ### Required Arguments
 `user` - The user you want to blacklist.
 ### Usage
 ```
-.blacklist [user]
+.blacklist <user>
 ```
 ### Aliases
 `bl`, `disallow`
 ### Permission Required
-Any user with the **Manage Server** permission, a configured admin role or a configured staff role can use this command.
+The user must have **Manage Server** or a configured staff role.

--- a/staff/comment.md
+++ b/staff/comment.md
@@ -1,16 +1,16 @@
 # Comment
 ---
 ### Description
-This command allows staff members to comment on a suggestion. This comment will be displayed publicly in the suggestion embed.
+This command allows staff members to add comments to a suggestion. The comment will be displayed publicly in the suggestion feed.
 ### Required Arguments
-`suggestion ID` - The ID of the suggestion you want to comment on
+`suggestionId` - The ID of the suggestion.
 
-`comment` - The comment to add to the suggestion
+`comment` - The comment to add.
 
 !> A suggestion can have a maximum of 23 comments
 ### Usage
 ```
-.comment [suggestion id] [comment]
+.comment <suggestionId> <comment>
 ```
 ### Permission Required
-Any user with the **Manage Server** permission, a configured admin role or a configured staff role can use this command.
+The user must have **Manage Server** or a configured staff role.

--- a/staff/delete.md
+++ b/staff/delete.md
@@ -3,12 +3,12 @@
 ### Description
 This command is used to delete an approved suggestion.
 ### Required Arguments
-`suggestion ID` - The ID of the suggestion you want to delete.
+`suggestionId` - The ID of the suggestion you want to delete.
 ### Optional Arguments
-`reason` - The reason of deleting the suggestion.
+`reason` - The reason the suggestion is being deleted.
 ### Usage
 ```
-.delete [suggestion ID] (reason)
+.delete <suggestionId> [reason]
 ```
 ### Permission Required
-Any user with the **Manage Server** permission, a configured admin role or a configured staff role can use this command.
+The user must have **Manage Server** or a configured staff role.

--- a/staff/deletecomment.md
+++ b/staff/deletecomment.md
@@ -3,12 +3,12 @@
 ### Description
 This command is used to delete a comment from a suggestion.
 ### Required Arguments
-`comment ID` - The ID of the comment you want to delete.
+`commentId` - The ID of the comment you want to delete.
 ### Usage
 ```
-.deletecomment [comment ID]
+.deletecomment [commentId]
 ```
 ### Aliases
 `delcomment`, `dcomment`, `rmcomment`
 ### Permission Required
-Any user with the **Manage Server** permission, a configured admin role or a configured staff role can use this command.
+The user must have **Manage Server** or a configured staff role.

--- a/staff/deny.md
+++ b/staff/deny.md
@@ -3,12 +3,12 @@
 ### Description
 This command is used to deny a suggestions in review mode.
 ### Required Arguments
-`suggestion ID` - The ID of the suggestion you want to deny.
+`suggestionId` - The ID of the suggestion you want to deny.
 ### Optional Arguments
-`reason` - The reason of denying the suggestion.
+`reason` - The reason the suggestion is being denied.
 ### Usage
 ```
-.deny [suggestion ID] (reason)
+.deny <suggestionId> [reason]
 ```
 ### Permission Required
-Any user with the **Manage Server** permission, a configured admin role or a configured staff role can use this command.
+The user must have **Manage Server** or a configured staff role.

--- a/staff/info.md
+++ b/staff/info.md
@@ -1,12 +1,12 @@
 # Info
 ---
 ### Description
-This command is used to get info of a suggestion.
+Get info about an approved suggestion
 ### Required Arguments
-`suggestion ID` - The ID of the suggestion you want to get info about.
+`suggestionId` - The ID of the suggestion.
 ### Usage
 ```
-.info [suggestion ID]
+.info <suggestionId>
 ```
 ### Permission Required
-Any user with the **Manage Server** permission, a configured admin role or a configured staff role can use this command.
+The user must have **Manage Server** or a configured staff role.

--- a/staff/listqueue.md
+++ b/staff/listqueue.md
@@ -1,7 +1,7 @@
 # Listqueue
 ---
 ### Description
-This command is used to show all suggestions awaiting review.
+Get a list of all suggestions currently in the suggestion queue. (Note: you must be in review mode to use this command.)
 ### Usage
 ```
 .listqueue
@@ -9,4 +9,4 @@ This command is used to show all suggestions awaiting review.
 ### Aliases
 `queue`, `showqueue`
 ### Permission Required
-Any user with the **Manage Server** permission, a configured admin role or a configured staff role can use this command.
+The user must have **Manage Server** or a configured staff role.

--- a/staff/mark.md
+++ b/staff/mark.md
@@ -3,9 +3,9 @@
 ### Description
 This command is used to change the status of a suggestion.
 ### Required Arguments
-`suggestion ID` - The ID of the suggestion you want to change it's status.
+`suggestionId` - The ID of the suggestion.
 
-`status` - The status you want to use.
+`status` - The status you want to set.
 
 | Argument              |                Meaning                |
 |-----------------------|:-------------------------------------:|
@@ -17,9 +17,9 @@ This command is used to change the status of a suggestion.
 
 ### Usage
 ```
-.mark [suggestion ID] [status]
+.mark <suggestionId> <status>
 ```
 ### Aliases
 `status`
 ### Permission Required
-Any user with the **Manage Server** permission, a configured admin role or a configured staff role can use this command.
+The user must have **Manage Server** or a configured staff role.

--- a/staff/massapprove.md
+++ b/staff/massapprove.md
@@ -3,16 +3,16 @@
 ### Description
 This command is used to approve multiple suggestions at once.
 ### Required Arguments
-`suggestions IDs` - The suggestions' IDs that you want to approve.
+`suggestionIds` - The suggestion IDs that you want to approve.
 ### Optional Arguments
-`comment` - Comment you want to include in the suggestion.
+`comment` - A comment that you want to include on all of the approved suggestions.
 
-?> You have to separate the suggestions IDs and the comment with `-r`
+?> You have to separate the suggestion IDs and the comment with `-r`
 ### Usage
 ```
-.massapprove [suggestions IDs] (comment)
+.massapprove <suggestionIds> [-r <comment>]
 ```
 ### Aliases
 `mapprove`, `multiapprove`
 ### Permission Required
-Any user with the **Manage Server** permission, a configured admin role or a configured staff role can use this command.
+The user must have **Manage Server** or a configured staff role.

--- a/staff/massdelete.md
+++ b/staff/massdelete.md
@@ -3,16 +3,16 @@
 ### Description
 This command is used to delete multiple suggestions at once.
 ### Required Arguments
-`suggestions IDs` - The suggestions' IDs that you want to delete.
+`suggestionIds` - The suggestion IDs that you want to delete.
 ### Optional Arguments
-`reason` - The reason of deleting the suggestions.
+`reason` - The reason for deleting the suggestions.
 
-?> You have to separate the suggestions IDs and the reason with `-r`
+?> You have to separate the suggestion IDs and the reason with `-r`
 ### Usage
 ```
-.massdelete [suggestions IDs] (reason)
+.massdelete <suggestionIds> [-r <reason>]
 ```
 ### Aliases
 `medelete`, `multidelete`
 ### Permission Required
-Any user with the **Manage Server** permission, a configured admin role or a configured staff role can use this command.
+The user must have **Manage Server** or a configured staff role.

--- a/staff/massdeny.md
+++ b/staff/massdeny.md
@@ -3,16 +3,16 @@
 ### Description
 This command is used to deny multiple suggestions at once.
 ### Required Arguments
-`suggestions IDs` - The suggestions' IDs that you want to deny.
+`suggestionIds` - The suggestion IDs that you want to deny.
 ### Optional Arguments
-`reason` - The reason of denying the suggestions.
+`reason` - The reason for denying the suggestions.
 
 ?> You have to separate the suggestions IDs and the reason with `-r`
 ### Usage
 ```
-.massdeny [suggestions IDs] (reason)
+.massdeny <suggestionIds> [-r <reason>]
 ```
 ### Aliases
 `mdeny`, `multideny`
 ### Permission Required
-Any user with the **Manage Server** permission, a configured admin role or a configured staff role can use this command.
+The user must have **Manage Server** or a configured staff role.

--- a/staff/removeattachment.md
+++ b/staff/removeattachment.md
@@ -3,12 +3,12 @@
 ### Description
 This command is used to remove attachment from a suggestion.
 ### Required Arguments
-`suggestion ID` - The ID of the suggestion that you want to remove the attachment from.
+`suggestionId` - The ID of the suggestion.
 ### Usage
 ```
-.removeattachment [suggestion ID]
+.removeattachment <suggestionId>
 ```
 ### Aliases
 `rmattachment`, `rmattach`, `delattachment`, `deleteattachment`
 ### Permission Required
-Any user with the **Manage Server** permission, a configured admin role or a configured staff role can use this command.
+The user must have **Manage Server** or a configured staff role.

--- a/staff/silentdeny.md
+++ b/staff/silentdeny.md
@@ -1,14 +1,14 @@
 # Silentdeny
 ---
 ### Description
-This command is used to deny a suggestion but not send it to the denied suggestion channel, The user still get DMed.
+This command is used to deny a suggestion without sending it to the denied suggestion channel. The user will still be DM'd.
 ### Required Arguments
-`suggestion ID` - The ID of the suggestion that you want to deny silently.
+`suggestionId` - The ID of the suggestion.
 ### Optional Arguments
-`reason` - The reason of denying the suggestion
+`reason` - The reason for denying the suggestion.
 ### Usage
 ```
-.silentdeny [suggestion ID] (reason)
+.silentdeny <suggestionId> [reason]
 ```
 ### Permission Required
-Any user with the **Manage Server** permission, a configured admin role or a configured staff role can use this command.
+The user must have **Manage Server** or a configured staff role.

--- a/staff/unblacklist.md
+++ b/staff/unblacklist.md
@@ -1,14 +1,14 @@
 # Unblacklist
 ---
 ### Description
-This command is used to let blacklisted people use the bot in the server again.
+This command is will remove users from the server blacklist.
 ### Required Arguments
 `user` - The user you want to unblacklist.
 ### Usage
 ```
-.unblacklist [user]
+.unblacklist <user>
 ```
 ### Aliases
 `unbl`, `allow`
 ### Permission Required
-Any user with the **Manage Server** permission, a configured admin role or a configured staff role can use this command.
+The user must have **Manage Server** or a configured staff role.

--- a/supporting/info.md
+++ b/supporting/info.md
@@ -1,6 +1,6 @@
 # Supporting the Bot
 ---
-The best way to support the bot is by voting for it on bot lists. If you are in the [Support Server](https://discord.gg/G5pEdUp), you can get rewards for voting!
+The best way to support the bot is by voting on bot lists. If you are in the [support server](https://discord.gg/G5pEdUp), you can even get rewards for voting!
 
 <!-- tabs:start -->
 

--- a/translation.md
+++ b/translation.md
@@ -1,5 +1,5 @@
 # Documentation Translations
 
 If you are interested in helping translate Suggester's documentation, you will need to be a part of our translation team! If you are not yet part of the translation team, hit us up in our support server and we'll get you started!
-More info can be found [here](https://discord.gg/G5pEdUp)! Otherwise, send `@Suggester Support#5646` a DM saying that you're interested in helping translate the documentation so we can get everything ready for you and get you started. We will be doing translations through GitHub, so having a basic understanding of how [Git](https://git-scm.com/docs/gittutorial) and/or [GitHub](https://help.github.com/en/github) work would definitely be in your best interest.
+More info can be found [here](https://discord.gg/G5pEdUp)! Otherwise, send `@Suggester Support#5646` a DM saying that you're interested in helping translate the documentation so we can get everything ready for you and get you started. We will be doing translations through GitHub, so having a basic understanding of how [Git](https://git-scm.com/docs/gittutorial) and [GitHub](https://help.github.com/en/github) work would definitely be in your best interest.
 If, at any point in the translation process, you have any questions, feel free to send `@Suggester Support#5646` a DM and we will be happy to assist you.

--- a/usefullinks.md
+++ b/usefullinks.md
@@ -8,18 +8,18 @@ All useful links that relate to the bot.
 
 # Bot Invite
 ---
-### To invite our bot, [click here to invite the bot!](https://discord.com/oauth2/authorize?client_id=564426594144354315&scope=bot&permissions=805694544)
+### You can use [this link](https://discord.com/oauth2/authorize?client_id=564426594144354315&scope=bot&permissions=805694544) to invite the bot!
 
 #### **Support Server**
 
 # Support Server Invite
 ---
-### [Click here](https://discord.gg/G5pEdUp) to join the support server where you can be notified of updates, get help with the bot, and more!
+### [Click here](https://discord.gg/G5pEdUp) to join the support server, where you can be notified of updates and receive help with the bot!
 
 #### **Twitter**
 
 # Twitter
 ---
-### [Click here](https://twitter.com/SuggesterBot) to look at our twitter! You can get notified about updates, status updates, polls and more to come!
+### We even have a [Twitter](https://twitter.com/SuggesterBot)! We will be using it to announce updates, outages and polls!
 
 <!-- tabs:end -->


### PR DESCRIPTION
I changed a lot of the commands documentation to follow one specific
format.

Command params follow bash/unix command syntax:
- `<>` - Required params
- `[]` - Optional params
- `[one|two]` - One or another

Changed the permission message because saying it can be used by anyone
except users who are blacklisted is a bit redundant.

Fixed a few typos